### PR TITLE
Allows to authenticate with other (or multiple) fields then 'username'

### DIFF
--- a/config/oauth2.doctrine-orm.global.php.dist
+++ b/config/oauth2.doctrine-orm.global.php.dist
@@ -14,6 +14,7 @@ return array(
             'driver' => 'doctrine.driver.orm_default',
             'enable_default_entities' => true,
             'bcrypt_cost' => 14, # match zfcuser
+            'auth_identity_fields' => array('username'),
             // Dynamically map the user_entity to the client_entity
             'dynamic_mapping' => array(
                 'user_entity' => array(

--- a/src/Adapter/DoctrineAdapter.php
+++ b/src/Adapter/DoctrineAdapter.php
@@ -167,6 +167,14 @@ class DoctrineAdapter implements
     {
         $this->config = array_merge($this->config, $config);
 
+        if (!isset($this->config['auth_identity_fields'])) {
+            $this->config['auth_identity_fields'] = 'username';
+        }
+
+        if (!is_array($this->config['auth_identity_fields'])) {
+            $this->config['auth_identity_fields'] = array($this->config['auth_identity_fields']);
+        }
+
         return $this;
     }
 

--- a/src/Adapter/DoctrineAdapter.php
+++ b/src/Adapter/DoctrineAdapter.php
@@ -167,10 +167,12 @@ class DoctrineAdapter implements
     {
         $this->config = array_merge($this->config, $config);
 
+        // Used to be hardcoded as plain string.
         if (!isset($this->config['auth_identity_fields'])) {
             $this->config['auth_identity_fields'] = 'username';
         }
 
+        // To prevent BC issues with configurations now we wrap the singular default into an array
         if (!is_array($this->config['auth_identity_fields'])) {
             $this->config['auth_identity_fields'] = array($this->config['auth_identity_fields']);
         }
@@ -768,7 +770,9 @@ class DoctrineAdapter implements
             $qb->orWhere(sprintf("u.%s = :username", $doctrineField));
         }
 
-        if ($user = $qb->getQuery()->getOneOrNullResult()) {
+        $user = $qb->getQuery()->getOneOrNullResult();
+
+        if ($user) {
             $mapper = $this->getServiceLocator()->get('ZF\OAuth2\Doctrine\Mapper\User')->reset();
             $mapper->exchangeDoctrineArray($user->getArrayCopy());
 
@@ -809,7 +813,9 @@ class DoctrineAdapter implements
             $qb->orWhere(sprintf("u.%s = :username", $doctrineField));
         }
 
-        if ($user = $qb->getQuery()->getOneOrNullResult()) {
+        $user = $qb->getQuery()->getOneOrNullResult();
+
+        if ($user) {
             $mapper = $this->getServiceLocator()->get('ZF\OAuth2\Doctrine\Mapper\User')->reset();
             $mapper->exchangeDoctrineArray($user->getArrayCopy());
 

--- a/src/Adapter/DoctrineAdapter.php
+++ b/src/Adapter/DoctrineAdapter.php
@@ -760,10 +760,12 @@ class DoctrineAdapter implements
             ->setParameter('username', $username);
 
         foreach ($config['auth_identity_fields'] as $field) {
-            $qb->orWhere(sprintf(
-                    "u.%s = :username",
-                    $config['mapping']['ZF\OAuth2\Doctrine\Mapper\User']['mapping'][$field]['name'])
-            );
+            if (isset($config['mapping']['ZF\OAuth2\Doctrine\Mapper\User']['mapping'][$field]['name'])) {
+                $doctrineField = $config['mapping']['ZF\OAuth2\Doctrine\Mapper\User']['mapping'][$field]['name'];
+            } else {
+                $doctrineField = $field;
+            }
+            $qb->orWhere(sprintf("u.%s = :username", $doctrineField));
         }
 
         if ($user = $qb->getQuery()->getOneOrNullResult()) {
@@ -799,10 +801,12 @@ class DoctrineAdapter implements
             ->setParameter('username', $username);
 
         foreach ($config['auth_identity_fields'] as $field) {
-            $qb->orWhere(sprintf(
-                    "u.%s = :username",
-                    $config['mapping']['ZF\OAuth2\Doctrine\Mapper\User']['mapping'][$field]['name'])
-            );
+            if (isset($config['mapping']['ZF\OAuth2\Doctrine\Mapper\User']['mapping'][$field]['name'])) {
+                $doctrineField = $config['mapping']['ZF\OAuth2\Doctrine\Mapper\User']['mapping'][$field]['name'];
+            } else {
+                $doctrineField = $field;
+            }
+            $qb->orWhere(sprintf("u.%s = :username", $doctrineField));
         }
 
         if ($user = $qb->getQuery()->getOneOrNullResult()) {

--- a/src/Adapter/DoctrineAdapter.php
+++ b/src/Adapter/DoctrineAdapter.php
@@ -745,17 +745,20 @@ class DoctrineAdapter implements
     public function checkUserCredentials($username, $password)
     {
         $config = $this->getConfig();
-        $doctrineUsernameField = $config['mapping']['ZF\OAuth2\Doctrine\Mapper\User']['mapping']['username']['name'];
+        $qb     = $this->getObjectManager()->createQueryBuilder();
 
-        $user = $this->getObjectManager()
-            ->getRepository($config['mapping']['ZF\OAuth2\Doctrine\Mapper\User']['entity'])
-            ->findOneBy(
-                array(
-                    $doctrineUsernameField => $username,
-                )
+        $qb->select(array('u'))
+            ->from($config['mapping']['ZF\OAuth2\Doctrine\Mapper\User']['entity'], 'u')
+            ->setParameter('username', $username);
+
+        foreach ($config['auth_identity_fields'] as $field) {
+            $qb->orWhere(sprintf(
+                    "u.%s = :username",
+                    $config['mapping']['ZF\OAuth2\Doctrine\Mapper\User']['mapping'][$field]['name'])
             );
+        }
 
-        if ($user) {
+        if ($user = $qb->getQuery()->getOneOrNullResult()) {
             $mapper = $this->getServiceLocator()->get('ZF\OAuth2\Doctrine\Mapper\User')->reset();
             $mapper->exchangeDoctrineArray($user->getArrayCopy());
 
@@ -781,17 +784,20 @@ class DoctrineAdapter implements
     public function getUserDetails($username)
     {
         $config = $this->getConfig();
-        $doctrineUsernameField = $config['mapping']['ZF\OAuth2\Doctrine\Mapper\User']['mapping']['username']['name'];
+        $qb     = $this->getObjectManager()->createQueryBuilder();
 
-        $user = $this->getObjectManager()
-            ->getRepository($config['mapping']['ZF\OAuth2\Doctrine\Mapper\User']['entity'])
-            ->findOneBy(
-                array(
-                    $doctrineUsernameField => $username,
-                )
+        $qb->select(array('u'))
+            ->from($config['mapping']['ZF\OAuth2\Doctrine\Mapper\User']['entity'], 'u')
+            ->setParameter('username', $username);
+
+        foreach ($config['auth_identity_fields'] as $field) {
+            $qb->orWhere(sprintf(
+                    "u.%s = :username",
+                    $config['mapping']['ZF\OAuth2\Doctrine\Mapper\User']['mapping'][$field]['name'])
             );
+        }
 
-        if ($user) {
+        if ($user = $qb->getQuery()->getOneOrNullResult()) {
             $mapper = $this->getServiceLocator()->get('ZF\OAuth2\Doctrine\Mapper\User')->reset();
             $mapper->exchangeDoctrineArray($user->getArrayCopy());
 


### PR DESCRIPTION
Inspired by ZfcUser. Need to be able to authenticate with username and/or email field?

- [x] adds a conf key 'auth_identity_fields' just as ZfcUser has. They are doctrine field names
- [x] fully backward compatible
- [ ] testing
- [ ] documentation