### PR TITLE
Invalidating of JTI token not done due to incorrect key returned

### DIFF
--- a/config/oauth2.doctrine-orm.global.php.dist
+++ b/config/oauth2.doctrine-orm.global.php.dist
@@ -254,7 +254,7 @@ return array(
                             'name' => 'audience',
                             'datatype' => 'string',
                         ),
-                        'expiration' => array(
+                        'expires' => array(
                             'type' => 'field',
                             'name' => 'expires',
                             'datatype' => 'datetime',

--- a/src/Adapter/DoctrineAdapter.php
+++ b/src/Adapter/DoctrineAdapter.php
@@ -1233,14 +1233,14 @@ class DoctrineAdapter implements
         $client_id,
         $subject,
         $audience,
-        $expiration,
+        $expires,
         $jti
     ) {
         $config = $this->getConfig();
         $doctrineClientIdField = $config['mapping']['ZF\OAuth2\Doctrine\Mapper\Jti']['mapping']['client_id']['name'];
         $doctrineSubjectField = $config['mapping']['ZF\OAuth2\Doctrine\Mapper\Jti']['mapping']['subject']['name'];
         $doctrineAudienceField = $config['mapping']['ZF\OAuth2\Doctrine\Mapper\Jti']['mapping']['audience']['name'];
-        $doctrineExpirationField = $config['mapping']['ZF\OAuth2\Doctrine\Mapper\Jti']['mapping']['expiration']['name'];
+        $doctrineExpirationField = $config['mapping']['ZF\OAuth2\Doctrine\Mapper\Jti']['mapping']['expires']['name'];
         $doctrineJtiField = $config['mapping']['ZF\OAuth2\Doctrine\Mapper\Jti']['mapping']['jti']['name'];
 
         $mapper = $this->getServiceLocator()->get('ZF\OAuth2\Doctrine\Mapper\Jti')->reset();
@@ -1248,7 +1248,7 @@ class DoctrineAdapter implements
             'client_id' => $client_id,
             'subject' => $subject,
             'audience' => $audience,
-            'expiration' => $expiration,
+            'expires' => $expires,
             'jti' => $jti,
         ));
 


### PR DESCRIPTION
fix a minor typo
 
JwtBearerInterface::getJti() should return an array with 'expires', not 'expiration'. Changes to the map are mainly for naming consistency...

see : https://github.com/bshaffer/oauth2-server-php/blob/144994292f219b55814009477300eb32ab1fbf37/src/OAuth2/Storage/JwtBearerInterface.php#L54