### PR TITLE
key must match config name

### DIFF
--- a/src/Adapter/DoctrineAdapter.php
+++ b/src/Adapter/DoctrineAdapter.php
@@ -544,7 +544,7 @@ class DoctrineAdapter implements
         $mapper->exchangeOAuth2Array(array(
             'access_token' => $access_token,
             'client_id' => $client_id,
-            'user_id' => $user_id,
+            'user' => $user_id,
             'expires' => $expires,
             'scope' => $scope,
         ));


### PR DESCRIPTION
It seems the key change here must match the name field from this configuration or an exception is thrown

https://github.com/TomHAnderson/zf-oauth2-doctrine/blob/master/config/oauth2.doctrine-orm.global.php.dist#L159

```
http POST https://example.com/oauth client_id=XXX client_secret=XXX redirect_uri=http://example.com grant_type=client_credentials --verify=no

HTTP/1.1 500 Internal Server Error
Connection: close
Content-Type: application/problem+json
Date: Fri, 29 May 2015 12:09:24 GMT
Server: Apache/2.4.10 (Unix) OpenSSL/0.9.8zd mod_fastcgi/2.4.6
Transfer-Encoding: chunked
X-Powered-By: PHP/5.5.18

{
    "detail": "Relation was not found: user_id:", 
    "status": 500, 
    "title": "Internal Server Error", 
    "trace": [
        {
            "args": [
                {
                    "access_token": "053380c2abccdeb522b82828891973c53d6d12df", 
                    "client_id": "XXX", 
                    "expires": 1432904964, 
                    "scope": "testscope", 
                    "user_id": null
                }
            ], 
            "class": "ZF\\OAuth2\\Doctrine\\Mapper\\AbstractMapper", 
            "file": "./vendor/zfcampus/zf-oauth2-doctrine/src/Adapter/DoctrineAdapter.php", 
            "function": "exchangeOAuth2Array", 
            "line": 550, 
            "type": "->"
        }, 
        {

```